### PR TITLE
Feature/gh actions (#33)

### DIFF
--- a/.github/workflows/bookdown_action.yml
+++ b/.github/workflows/bookdown_action.yml
@@ -1,0 +1,60 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# github docs on actions https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions
+
+# borrowed caching and dependency install from https://github.com/ropenscilabs/statistical-software-review-book/blob/main/.github/workflows/main.yml
+on:
+  push:
+    branches: [main, master]
+
+name: bookdown
+
+jobs:
+  bookdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      AUTHOR: ${{ github.event.pusher.name }}
+    steps:
+# check for more recent versions
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+# potentially drop to keep from locking package versions
+# look into how this impacts build 
+      - uses: r-lib/actions/setup-renv@v1
+
+      - name: Install libgit2
+        run: sudo apt install libgit2-dev
+        
+      - name: Cache bookdown results
+        uses: actions/cache@v2
+        with:
+          path: _bookdown_files
+          key: bookdown-${{ hashFiles('**/*Rmd') }}
+          restore-keys: bookdown-
+      
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: r-${{ hashFiles('DESCRIPTION') }}
+          restore-keys: r-
+      
+      - name: Install dependencies
+        run: Rscript -e 'install.packages("remotes")' -e 'remotes::install_deps(dependencies = TRUE)'
+      # should we build bookdown::gitbook vs default?
+      - name: Build site
+        run: Rscript -e 'bookdown::render_book("index.Rmd", quiet = TRUE)'
+# generate pdf? see R open sci
+# Maelle - bootstrap 4 - nicer format (change output format )
+# see hand coded examples from Mark -
+      - name: Deploy to GitHub pages 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: _book #added folder but unclear if it will still be missing

--- a/_404.rmd
+++ b/_404.rmd
@@ -1,0 +1,5 @@
+## ...Oops Page Not Found
+
+### Error 404
+
+This page doesn't exist or has moved. Try searching for the topic or [Click here]( "https://ecohealthalliance.github.io/eha-ma-handbook/") to go to the homepage.

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -16,7 +16,7 @@ rmd_files:
     - "stats-methods.Rmd"
     - "data-sources.Rmd"
     - "references.Rmd"
-    -  "training-resources-and-plans.Rmd"
+    - "training-resources-and-plans.Rmd"
     - "getting-help.Rmd"
     - "training-resources-and-plans.Rmd"
 book_filename: "eha-ma-handbook"
@@ -24,5 +24,5 @@ repo: https://github.com/ecohealthalliance/eha-ma-handbook/
 language:
   ui:
     chapter_name: ""
-output_dir: "docs"
+output_dir: "_book"
 delete_merged_file: true

--- a/data-strategy-annotated-bib.Rmd
+++ b/data-strategy-annotated-bib.Rmd
@@ -1,0 +1,7 @@
+# Data Strategy Resources 
+
+### Developing a modern data workflow for regularly udpated data
+DOI: https://doi.org/10.1371/journal.pbio.3000125
+
+This paper provides a concise primer on automated data ingestion for field ecologist. They discusses the workflow of a long term (40 year) study that processes data coming from instruments and human observation at frequencies ranging from hours to years. They describe methods for appropriate attribution, establishing institutional practices, version control, qa/qc and automation. Continuous integration software like TRAVIS CI can be used to run automated tests. **The authors could provide additional resources on creating tests and understanding limitations** The authors also touch on automating metadata creation for sampling events using TRAVIS CI and github. Given the frequent changes made to these data, a data versioning system has to be employed in order to understand provenance. 
+

--- a/getting-help.Rmd
+++ b/getting-help.Rmd
@@ -38,3 +38,15 @@ Also, outside EHA:
 If there's a course, workshop, or conference you want to attend to improve these
 skills, speak with your supervisor, we can often support this.  [DataCamp courses](https://www.datacamp.com/onboarding/learn?from=home&technology=r) are also potentially useful.
 If you feel they would match your learning style and needs, discuss EHA purchasing a subscription for you with your supervisor.
+
+## Minimal reproducible examples - helping others help you
+
+Minimal reproducible examples are small, self-contained code and data packets 
+that will allow others to recreate the issue you are experiencing on their 
+machine. The [reprex package](https://reprex.tidyverse.org/articles/articles/learn-reprex.html) is
+really helpful for creating preformatted code for github, stackoverflow, or slack. 
+This [stackoverflow answer](https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example) provides a succinct walk through of how to create a 
+minimal reproducible example. 
+
+
+

--- a/projects.Rmd
+++ b/projects.Rmd
@@ -20,7 +20,7 @@ weekly M&A meetings. Report-outs should include
 
 -   Progress on tasks assigned and completed in previous cycle
 -   Substantive report-out of results and products
--   Draft plan for tasks and goals for the coming cycle
+-   Draft plan for tasks and goals for the coming cycle 
 -   Team assignments for the next cycle and level of involvement (high
     (&gt;50%), medium (25%-50%, low (&lt;25%)) of team memberss over the cycle.
 -   Any additional deadlines or reporting anticipated in that time frame,
@@ -32,7 +32,7 @@ and set a date for the next one.
 Teams track work cycle progress through various mechanisms based on team
 preferences. One option is GitHub Milestones
 ([Example](https://github.com/ecohealthalliance/asl2050-ai/milestones)). Others
-use Google Spreadsheets, [Asana](https://asana.com/), or other systems. Teams
+use Google Spreadsheets,  [Air tables](https://airtable.com/), or other systems. Teams
 may choose what they prefer as long as their system
 
 -   Shows current tasks, deadlines, and assignments Tracks past tasks,
@@ -41,6 +41,8 @@ may choose what they prefer as long as their system
 -   Is available in "real time" online rather than stored on individual machines
     and e-mailed
 -   Can be made accessible to other staff via a URL but kept private within EHA
+
+*note*: historically teams had used [Asana](https://asana.com/)
 
 ## Setup and materials Organization
 
@@ -63,7 +65,7 @@ exploratory analyses, and final products. In organizing a project folder, ask
 
 -   There are some exceptions for large data sets or rapidly changing data sets.
     In these cases, data can be organized as a separate folder or project, and
-    large data sets can be store in an Amazon Web Services S3 bucket.
+    large data sets can be stored in an Amazon Web Services S3 bucket.
 
 -   In many cases it is actually best for data to be organized as a *separate
     repository* from analysis. This allows multiple analysis projects to rely on

--- a/quickstart.Rmd
+++ b/quickstart.Rmd
@@ -35,7 +35,7 @@ users):
 
 -   [Homebrew](https://brew.sh/) for general package management
 -   [iTerm2](https://www.iterm2.com/) for a better shell interface.
-    (`brew cask install iterm2` using Homebrew in the shell)
+    (`brew cask install iterm2` or `brew install --cask iterm2` using Homebrew in the shell)
 -   [mosh](https://mosh.org/) for connecting to our high-performance servers
     (`brew install mosh` using Homebrew in the shell)
 -   [hub](https://hub.github.com/) for interacting with GitHub from the shell (`brew install hub`)

--- a/r.Rmd
+++ b/r.Rmd
@@ -41,3 +41,11 @@ If you feel they would match your learning style and needs, discuss EHA purchasi
 These resources are largely about the mechanics of programming in R, rather
 than using it for statistical analyses.  This is a far larger subject, but see
 the [Statistical Methods] section for a jumping-off point.  
+
+## Additional Resources
+
+**Trouble shooting your code**: [Getting Help]. 
+
+**User groups/communities of practice**: [R Meetups](https://www.meetup.com/pro/r-user-groups)
+
+**Specific domains**: [Training Plans]


### PR DESCRIPTION
* Update quickstart.Rmd

updated command for brew cask install to reflect new syntax in homebrew.

* Update projects.Rmd

add airtables to project management tools. Consider dropping asana unless other groups are using it

* Update projects.Rmd

fixed tense of "store" on line 66

* added link to help chapter in R chapter

* added links to R meetups and training plan section

* added section on creating minimal reproducible examples and reprex package

* made asana a note at the end of the section in case anyone needs to dig those projects up

* adding initial data strategy summary

* added more annotation, need to finish discussion section

* initial commit of github action yml file

* updated workflow to install bookdown

* updated yml to make it a valid file

* added installs for addtional package dependencies

* removed git2r components

* changing build location to my fork

* removed commented out  git2r references from index.rmd

* added _book folder to gh-pages

* modified bookdown yaml to pull from cs repo

* adding no jekyll file

* changed output dir to _book

* changed repeated install calls to remotes::install_deps

* added caching for packages

* added 404 error message to meet functionality from reproducibility html file in build script

* update 404 rmd to be more informative

* reverted references to eha github account

* added subtitle back into the index page

* added step  install libgit2-dev, fiallowing for git2r to work i the subtitle

* added author attribute to env